### PR TITLE
Stop rarp packets being queued on garp socket

### DIFF
--- a/keepalived/vrrp/vrrp_arp.c
+++ b/keepalived/vrrp/vrrp_arp.c
@@ -214,6 +214,8 @@ void send_gratuitous_arp(vrrp_t *vrrp, ip_address_t *ipaddress)
  */
 void gratuitous_arp_init(void)
 {
+	int size = 0;
+
 	if (garp_buffer)
 		return;
 
@@ -227,6 +229,9 @@ void gratuitous_arp_init(void)
 		log_message(LOG_INFO, "Error %d while registering gratuitous ARP shared channel", errno);
 		return;
 	}
+
+	if (setsockopt(garp_fd, SOL_SOCKET, SO_RCVBUF, &size, sizeof(size)))
+		log_message(LOG_INFO, "setsockopt SO_RCVBUF for garp socket %d failed (%d) - %m", garp_fd, errno);
 
 	/* Initalize shared buffer */
 	garp_buffer = PTR_CAST(char, MALLOC(GARP_BUFFER_SIZE));


### PR DESCRIPTION
The rarp broadcast packets would be queued on garp socket, and consume system memory.
So we set the SO_RCVBUF to minimum size stop it.

[root@cpe ~]# ss -pf link
Netid  Recv-Q Send-Q                                                                                     Local Address:Port                                                                                                      Peer Address:Port                
p_raw  204800512 0                                                                                                   rarp:*                                                                                                                     *                      users:(("keepalived",pid=2547,fd=12))