### PR TITLE
Stop receiving any data on garp socket and ndisc socket

### DIFF
--- a/keepalived/vrrp/vrrp_arp.c
+++ b/keepalived/vrrp/vrrp_arp.c
@@ -228,6 +228,9 @@ void gratuitous_arp_init(void)
 		return;
 	}
 
+	/* We don't want to receive any data on this socket */
+	if_setsockopt_no_receive(&garp_fd);
+
 	/* Initalize shared buffer */
 	garp_buffer = PTR_CAST(char, MALLOC(GARP_BUFFER_SIZE));
 }

--- a/keepalived/vrrp/vrrp_ndisc.c
+++ b/keepalived/vrrp/vrrp_ndisc.c
@@ -275,6 +275,9 @@ ndisc_init(void)
 		log_message(LOG_INFO, "Error %d while registering gratuitous NDISC shared channel", errno);
 		return;
 	}
+
+	/* We don't want to receive any data on this socket */
+	if_setsockopt_no_receive(&ndisc_fd);
 }
 
 void


### PR DESCRIPTION
The rarp broadcast packets would be queued on garp socket, and consume system memory.
So we used filter stop receiving any data on garp socket and ndisc socket.

[root@cpe ~]# ss -pf link
Netid Recv-Q Send-Q Local Address:Port Peer Address:Port
p_raw 204800512 0 rarp:* * users:(("keepalived",pid=2547,fd=12))

Signed-off-by: Xing Qingjie <88930741@qq.com>